### PR TITLE
HOTFIX!: HTTP 415 error in kakao login

### DIFF
--- a/user/presentation/src/main/kotlin/vp/togedo/controller/UserController.kt
+++ b/user/presentation/src/main/kotlin/vp/togedo/controller/UserController.kt
@@ -25,7 +25,7 @@ class UserController(
     private val userConnector: UserConnector
 ) {
 
-    @GetMapping("/kakao-login", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("/kakao-login")
     @Operation(summary = "카카오 oauth를 사용한 로그인")
     @Parameters(
         Parameter(name = "code", description = "카카오 Oauth에서 발급받은 코드")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 

## 📝작업 내용

> kakao login에서 http 415 error가 발생, Http consume을 교체

<img width="658" alt="image" src="https://github.com/user-attachments/assets/dfa37e52-83f0-40a9-91f5-d4337dd6f81c">
