### PR TITLE
FIX: token Bearer prefix error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 docker/.env
 **/.env
+/http/http-client.private.env.json

--- a/http/user/reissue.http
+++ b/http/user/reissue.http
@@ -1,0 +1,22 @@
+# INVALID TOKEN
+GET http://localhost:12041/api/v1/user/reissue
+Authorization: INVALID_TOKEN
+
+> {%
+client.test("invalid_token", function () {
+    client.assert(response.status === 403)
+})
+ %}
+
+###
+#VALID TOKEN
+GET http://localhost:12041/api/v1/user/reissue
+Authorization: Bearer {{REFRESH_TOKEN}}
+
+> {%
+
+ client.test("valid_token", function (){
+     client.assert(response.status === 200)
+     client.assert(response.refreshToken === client.global.get("REFRESH_TOKEN"))
+ })
+ %}

--- a/user/presentation/src/main/kotlin/vp/togedo/connector/impl/UserConnectorImpl.kt
+++ b/user/presentation/src/main/kotlin/vp/togedo/connector/impl/UserConnectorImpl.kt
@@ -49,7 +49,9 @@ class UserConnectorImpl(
     override fun reissueAccessToken(refreshToken: String): LoginRes {
         return try{
             LoginRes(
-                userService.createJwtAccessToken(userService.getUserIdByToken(refreshToken)),
+                userService.createJwtAccessToken(
+                    userService.getUserIdByToken(refreshToken.removePrefix("Bearer "))
+                ),
                 refreshToken = refreshToken
             )
         }catch (malformedJwtException: MalformedJwtException){


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 

## 📝작업 내용

> refresh token을 추출하는 과정에서 Bearer prefix를 제거하지 않아 발생한 에러 수정
해당 API에 http test 추가
