### PR TITLE
REFACTOR: 유저의 이메일을 unique하도록 설정

### DIFF
--- a/user/core/src/main/kotlin/vp/togedo/service/UserService.kt
+++ b/user/core/src/main/kotlin/vp/togedo/service/UserService.kt
@@ -26,6 +26,13 @@ interface UserService {
         email: String? = null,
         profileImageUrl: String? = null): Mono<UserDocument>
 
+    fun insertOauthIdByEmail(
+        oauthEnum: OauthEnum,
+        kakaoId: Long? = null,
+        googleId: String? = null,
+        email: String
+    ): Mono<UserDocument>
+
     fun findUser(id: ObjectId): Mono<UserDocument>
 
     fun saveUser(userDocument: UserDocument): Mono<UserDocument>

--- a/user/core/src/test/kotlin/vp/togedo/service/impl/UserServiceImplTest.kt
+++ b/user/core/src/test/kotlin/vp/togedo/service/impl/UserServiceImplTest.kt
@@ -116,7 +116,7 @@ class UserServiceImplTest{
                     user.id == it.id
                 }.verifyComplete()
 
-            Mockito.verify(userRepository, times(1))
+            verify(userRepository, times(1))
                 .findByOauth_GoogleId(googleId)
         }
 
@@ -139,7 +139,7 @@ class UserServiceImplTest{
                 it is UserException && it.message == ErrorCode.USER_NOT_FOUND_BY_OAUTH.message
             }.verify()
 
-            Mockito.verify(userRepository, times(1))
+            verify(userRepository, times(1))
                 .findByOauth_GoogleId(googleId)
         }
     }

--- a/user/core/src/test/kotlin/vp/togedo/service/impl/UserServiceImplTest.kt
+++ b/user/core/src/test/kotlin/vp/togedo/service/impl/UserServiceImplTest.kt
@@ -4,7 +4,6 @@ import io.jsonwebtoken.MalformedJwtException
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.springframework.boot.test.mock.mockito.MockBean

--- a/user/persistence/src/main/kotlin/vp/togedo/UserRepository.kt
+++ b/user/persistence/src/main/kotlin/vp/togedo/UserRepository.kt
@@ -4,11 +4,12 @@ import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Mono
-import vp.togedo.document.Oauth
 import vp.togedo.document.UserDocument
 
 @Repository
 interface UserRepository: ReactiveMongoRepository<UserDocument, ObjectId>{
 
-    fun findByOauth(oauth: Oauth): Mono<UserDocument>
+    fun findByOauth_KakaoId(kakaoId: Long): Mono<UserDocument>
+    fun findByOauth_GoogleId(grantType: String): Mono<UserDocument>
+    fun findByEmail(email: String): Mono<UserDocument>
 }

--- a/user/persistence/src/main/kotlin/vp/togedo/document/UserDocument.kt
+++ b/user/persistence/src/main/kotlin/vp/togedo/document/UserDocument.kt
@@ -4,9 +4,6 @@ import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
-import org.springframework.data.mongodb.core.mapping.Field
-import org.springframework.data.mongodb.core.mapping.FieldType
-import vp.togedo.enums.OauthEnum
 
 @Document(collection = "user")
 data class UserDocument(
@@ -18,14 +15,13 @@ data class UserDocument(
 
     var name: String? = null,
 
+    @Indexed(unique = true)
     var email: String? = null,
 
     var profileImageUrl: String? = null,
 )
 
 data class Oauth(
-    @Field(targetType = FieldType.STRING)
-    val oauthType: OauthEnum,
-    val kakaoId: Long? = null,
-    val googleId: String? = null
+    var kakaoId: Long? = null,
+    var googleId: String? = null
 )


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #55

## 📝작업 내용

> 유저에서 각 이메일을 unique 하도록 지정(후에 검색기능을 추가하기 위해)
테스트 코드 업데이트